### PR TITLE
TEC-2863 Fix header z-index avoid prods to go over

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/StickyContainer/styled.js
+++ b/src/components/StickyContainer/styled.js
@@ -9,4 +9,5 @@ export const Content = styled.div`
   position: ${(p) => (p.sticked ? 'fixed' : 'relative')};
   top: 0;
   width: 100%;
+  z-index: 1;
 `


### PR DESCRIPTION
### What problem is the code solving?
Cms product carousel go over page header when scrolling

### How does this change address the problem?
We move the layer on top

