### PR TITLE
TEC-3194 changes to header component to adapt to pos logic

### DIFF
--- a/src/components/Header/components/HeaderDesktop/index.js
+++ b/src/components/Header/components/HeaderDesktop/index.js
@@ -26,7 +26,8 @@ function HeaderDesktop({
   onLogin,
   config,
   toggleSearch,
-  onClickTracking
+  onClickTracking,
+  pos
 }) {
   const [activeSection, setActiveSection] = useState(null)
   const layersMountingPoint = useRef(null)
@@ -46,6 +47,7 @@ function HeaderDesktop({
               activeSection={activeSection}
               layersMountingPoint={layersMountingPoint}
               onClickTracking={onClickTracking}
+              pos={pos}
             />
             <Logo href='/'>
               <MejuriLogo />
@@ -62,6 +64,7 @@ function HeaderDesktop({
                 isGuest={!user.email}
                 nameOrEmail={user.name || user.email}
                 onLogin={onLogin}
+                pos={pos}
               />
               <CartIcon
                 onClick={() => cartToggle()}
@@ -85,7 +88,8 @@ HeaderDesktop.propTypes = {
   }),
   onLogin: PropTypes.func,
   toggleSearch: PropTypes.func,
-  onClickTracking: PropTypes.func
+  onClickTracking: PropTypes.func,
+  pos: PropTypes.object
 }
 
 HeaderDesktop.defaultProps = {
@@ -94,7 +98,8 @@ HeaderDesktop.defaultProps = {
   },
   toggleSearch: function () {
     console.error('toggleSearch missing in <HeaderDesktop />')
-  }
+  },
+  pos: null
 }
 
 export default HeaderDesktop

--- a/src/components/Header/components/Navigation/index.js
+++ b/src/components/Header/components/Navigation/index.js
@@ -10,7 +10,8 @@ export const Navigation = ({
   setActive,
   activeSection,
   layersMountingPoint,
-  onClickTracking
+  onClickTracking,
+  pos
 }) => {
   // TODO: Temporary to avoid cms app to break bc of outdated data format.
   if (!config || !Array.isArray(config)) {
@@ -37,6 +38,7 @@ export const Navigation = ({
           activeSection={activeSection}
           mountingPoint={layersMountingPoint.current}
           onClickTracking={onClickTracking}
+          pos={pos}
         />
       )}
     </Wrapper>
@@ -52,7 +54,8 @@ Navigation.propTypes = {
   setActive: PropTypes.func,
   onClickTracking: PropTypes.func,
   activeSection: PropTypes.string,
-  layersMountingPoint: PropTypes.object
+  layersMountingPoint: PropTypes.object,
+  pos: PropTypes.object
 }
 
 export default Navigation

--- a/src/components/Header/components/NavigationLayers/index.js
+++ b/src/components/Header/components/NavigationLayers/index.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import { Layers, Layer, Column, MenuTitle, MenuItem } from './styled'
 import get from 'lodash.get'
 
-function ColumnContent({ config, onClickTracking }) {
+function ColumnContent({ config, onClickTracking, pos }) {
   return config.map((menuItem) => {
-    if (!menuItem.fields) {
-      return null
-    }
+    if (!menuItem.fields) return null
+    const isPosOnly = get(menuItem, 'fields.extraFields.posOnly', false)
+    if (isPosOnly && !pos) return null
     return (
       <MenuItem
         key={menuItem.sys.id}
@@ -25,7 +25,7 @@ function ColumnContent({ config, onClickTracking }) {
   })
 }
 
-function LayerContent({ config, onClickTracking, hasTitle }) {
+function LayerContent({ config, onClickTracking, hasTitle, pos }) {
   return hasTitle ? (
     <Column key={config.fields && config.sys.id}>
       <ColumnContent config={config} onClickTracking={onClickTracking} />
@@ -43,6 +43,7 @@ function LayerContent({ config, onClickTracking, hasTitle }) {
               <ColumnContent
                 config={col.fields.children}
                 onClickTracking={onClickTracking}
+                pos={pos}
               />
             )}
           </Column>
@@ -55,7 +56,8 @@ export const NavigationLayers = ({
   config,
   activeSection,
   mountingPoint,
-  onClickTracking
+  onClickTracking,
+  pos
 }) => {
   // TODO: Temporary to avoid cms app to break bc of outdated data format.
   if (!config || !Array.isArray(config)) {
@@ -70,6 +72,7 @@ export const NavigationLayers = ({
               config={s.fields.children}
               onClickTracking={onClickTracking}
               hasTitle={get(s, 'fields.extraFields.noTitle', null)}
+              pos={pos}
             />
           )}
         </Layer>

--- a/src/components/Header/components/UserSection/index.js
+++ b/src/components/Header/components/UserSection/index.js
@@ -4,13 +4,17 @@ import { FormattedMessage } from 'react-intl'
 import UserMenu from '../UserMenu'
 import { Wrapper, SignUpLink } from './styled'
 
-function UserSection({ isGuest, onLogin, nameOrEmail }) {
+function UserSection({ isGuest, onLogin, nameOrEmail, pos }) {
   return (
     <Wrapper>
       {isGuest ? (
-        <SignUpLink onClick={() => onLogin()}>
-          <FormattedMessage id='common.signup' />
-        </SignUpLink>
+        pos ? (
+          <SignUpLink>{pos.name}</SignUpLink>
+        ) : (
+          <SignUpLink onClick={() => onLogin()}>
+            <FormattedMessage id='common.signup' />
+          </SignUpLink>
+        )
       ) : (
         <UserMenu nameOrEmail={nameOrEmail} />
       )}
@@ -21,13 +25,15 @@ function UserSection({ isGuest, onLogin, nameOrEmail }) {
 UserSection.propTypes = {
   isGuest: PropTypes.bool,
   onLogin: PropTypes.func,
-  nameOrEmail: PropTypes.string
+  nameOrEmail: PropTypes.string,
+  pos: PropTypes.object
 }
 
 UserSection.defaultProps = {
   isGuest: true,
   nameOrEmail: '',
-  onLogin: () => {}
+  onLogin: () => {},
+  pos: null
 }
 
 export default UserSection

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -13,7 +13,8 @@ const Header = ({
   config,
   toggleSearch,
   onClickTracking,
-  children
+  children,
+  pos
 }) => (
   <Wrapper>
     <Content>
@@ -25,6 +26,7 @@ const Header = ({
         config={config}
         toggleSearch={toggleSearch}
         onClickTracking={onClickTracking}
+        pos={pos}
       />
       <HeaderMobile
         cartItemsCount={cartItemsCount}
@@ -45,7 +47,8 @@ Header.propTypes = {
   user: PropTypes.shape({
     isGuest: PropTypes.bool,
     nameOrEmail: PropTypes.string
-  })
+  }),
+  pos: PropTypes.object
 }
 
 Header.defaultProps = {
@@ -54,7 +57,8 @@ Header.defaultProps = {
   cartToggle: () => {},
   toggleMobileMenu: () => {},
   onClickTracking: (context) => {},
-  user: {}
+  user: {},
+  pos: null
 }
 
 export default Header

--- a/src/components/MobileMenu/components/MobileMenuDrawer/index.js
+++ b/src/components/MobileMenu/components/MobileMenuDrawer/index.js
@@ -2,8 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Header, Options, Item, PlusMinusToggle, Menu } from './styled'
+import get from 'lodash.get'
 
-export const MobileMenuDrawer = ({ toggle, label, isOpen, options }) => {
+export const filterOptions = (options, pos) => {
+  if (pos) return options
+  return options.filter(function (o) {
+    const isPosOnly = get(o, 'fields.extraFields.posOnly', false)
+    return !isPosOnly
+  })
+}
+
+export const MobileMenuDrawer = ({ toggle, label, isOpen, options, pos }) => {
   return (
     <Menu>
       <Header onClick={toggle}>
@@ -11,8 +20,8 @@ export const MobileMenuDrawer = ({ toggle, label, isOpen, options }) => {
         <PlusMinusToggle isOpen={isOpen} />
       </Header>
       {options && (
-        <Options length={options.length} isOpen={isOpen}>
-          {options.map((o) => (
+        <Options length={filterOptions(options, pos).length} isOpen={isOpen}>
+          {filterOptions(options, pos).map((o) => (
             <Item key={o.sys.id} sub={o.fields.type === 'subtitle'}>
               <a href={o.fields.url} onClick={(e) => e.stopPropagation()}>
                 {o.fields.text}
@@ -29,6 +38,7 @@ MobileMenuDrawer.propTypes = {
   toggle: PropTypes.func,
   label: PropTypes.string,
   isOpen: PropTypes.bool,
+  pos: PropTypes.object,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,

--- a/src/components/MobileMenu/index.js
+++ b/src/components/MobileMenu/index.js
@@ -119,8 +119,23 @@ export class MobileMenu extends React.Component {
     )
   }
 
+  filterOptions = (options, pos) => {
+    if (!pos) return options
+    return options.filter(function (o) {
+      const isAccount = get(o, 'fields.extraFields.account', false)
+      return isAccount
+    })
+  }
+
   render() {
-    const { menuOptions, itemQuantity, searchEnabled, isOpen, currencySelector } = this.props
+    const {
+      menuOptions,
+      itemQuantity,
+      searchEnabled,
+      isOpen,
+      currencySelector,
+      pos
+    } = this.props
     const { subPageOpen } = this.state
     if (!menuOptions) return null
     const bottomMenus = menuOptions.children.filter((x) =>
@@ -166,10 +181,11 @@ export class MobileMenu extends React.Component {
                     isOpen={this.state.openDrawer === o.sys.id}
                     options={o.fields.children}
                     glassClick={this.handleSearchClick}
+                    pos={pos}
                   />
                 ))}
                 <Footer>
-                  {bottomMenus.map((o) => (
+                  {this.filterOptions(bottomMenus, pos).map((o) => (
                     <FooterItem
                       onClick={() => this.handleFooterClick(o)}
                       key={o.sys.id}
@@ -216,7 +232,8 @@ MobileMenu.propTypes = {
   toggleCart: PropTypes.func,
   toggleSearch: PropTypes.func,
   openOnboarding: PropTypes.func,
-  currencySelector: PropTypes.element
+  currencySelector: PropTypes.element,
+  pos: PropTypes.object
 }
 
 export default MobileMenu


### PR DESCRIPTION
### What problem is the code solving?

Support showing links only in POS session.

If the user is GUEST, the store name should appear in the same place of the username appear for not POS sessions

### How does this change address the problem?

Contentful menu options has now an extraField name posOnly, is one option has this attribute and session has no pos it not shows.

It makes the changes to show the user state depending on if the user login in or if pos is on

### Why is this the best solution?

### Does this PR include proper unit testing?

### Share the knowledge
