### PR TITLE
[TEC-3441] Add user consent service to mejuri-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 node_modules
 example/node_modules
 example/build
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// REACT COMPONENTS
 export { default as Header } from './components/Header'
 export { default as NotificationBar } from './components/NotificationBar'
 export { default as TimedMessage } from './components/common/TimedMessage'
@@ -11,7 +12,14 @@ export { default as Overlay } from './components/common/Overlay'
 export { default as IsOnScreen } from './components/common/IsOnScreen'
 export { default as Footer } from './components/Footer'
 export { default as OnboardingModal } from './components/OnboardingModal'
+
+// SERVICES
 export { ContentfulAPI } from './services/ContentfulApi'
-export { default as Theme } from './themes/styled'
+export { default as UserConsent } from './services/UserConsent'
+
+// HELPERS
 export * from './helpers/itemDescription'
 export * from './helpers/currency'
+
+// OTHER
+export { default as Theme } from './themes/styled'

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,0 @@
-import { ExampleComponent } from '.'
-
-describe('ExampleComponent', () => {
-  it('is truthy', () => {
-    expect(ExampleComponent).toBeTruthy()
-  })
-})

--- a/src/services/UserConsent/__snapshots__/index.test.js.snap
+++ b/src/services/UserConsent/__snapshots__/index.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserConsent Active categories match user preferences (Functional) 1`] = `
+Array [
+  "Functional",
+  "Strictly Necessary",
+]
+`;
+
+exports[`UserConsent Active categories match user preferences (Performance) 1`] = `
+Array [
+  "Performance",
+  "Strictly Necessary",
+]
+`;
+
+exports[`UserConsent Active categories match user preferences (Social Media) 1`] = `
+Array [
+  "Social Media",
+  "Strictly Necessary",
+]
+`;
+
+exports[`UserConsent Active categories match user preferences (Strictly necessary) 1`] = `
+Array [
+  "Strictly Necessary",
+]
+`;
+
+exports[`UserConsent Active categories match user preferences (Targeting) 1`] = `
+Array [
+  "Targeting",
+  "Strictly Necessary",
+]
+`;
+
+exports[`UserConsent Available services match user preferences (Functional) 1`] = `Array []`;
+
+exports[`UserConsent Available services match user preferences (Performance) 1`] = `
+Array [
+  "Google Analytics",
+  "Mouseflow",
+  "Vimeo",
+  "Heap",
+]
+`;
+
+exports[`UserConsent Available services match user preferences (Social Media) 1`] = `Array []`;
+
+exports[`UserConsent Available services match user preferences (Strictly necessary) 1`] = `Array []`;
+
+exports[`UserConsent Available services match user preferences (Targeting) 1`] = `
+Array [
+  "Pinterest Tag",
+  "Facebook Pixel",
+  "Twitter Ads",
+]
+`;

--- a/src/services/UserConsent/index.js
+++ b/src/services/UserConsent/index.js
@@ -1,0 +1,165 @@
+const CONSENT_CATEGORIES_DICTIONARY = {
+  'C0001' : 'Strictly Necessary',
+  'C0002' : 'Performance',
+  'C0003' : 'Functional',
+  'C0004' : 'Targeting',
+  'C0005' : 'Social Media'
+}
+
+/*
+  Map services with the cookie categories that correspond
+*/
+const SERVICES_CATEGORIES = {
+  'Sailthru'                :['Targeting','Functional','Performance'],
+  'Google Analytics'        :['Performance'],
+  'Pinterest Tag'           :['Targeting'],
+  'Facebook Pixel'          :['Targeting'],
+  'Twitter Ads'             :['Targeting'],
+  'Google Tag Manager'      :['Strictly Necessary','Targeting','Functional','Performance','Social Media'],
+  'Mouseflow'               :['Performance'],
+  'Vimeo'                   :['Performance'],
+  'AdRoll'                  :['Performance','Targeting'],
+  'Google Ads (Gtag)'       :['Performance','Targeting'],
+  'Podsights'               :['Performance','Targeting'],
+  'Heap'                    :['Performance'],
+  'ShareASale'              :['Performance','Targeting'],
+  'The Trade Desk (Mejuri)' :['Performance','Targeting'],
+  'Privy'                   :['Performance','Functional']
+}
+
+
+class UserConsent{
+
+  consentCategories   = []
+  activeCategories    = []
+  servicesList        = []
+  availableServices   = []
+  unavailableServices = []
+  callbacks           = []
+  scripts             = []
+
+  constructor(){
+    this.onUpdate()
+    window.addEventListener('consent.onetrust',this._onConsentChange.bind(this))
+    window.addEventListener('load',this.onUpdate.bind(this))
+  }
+
+  onConsentChange(callback){
+    this.callbacks.push(callback)
+  }
+
+  removeOnConsentChange(callback){
+      this.callbacks = this.callbacks.filter( c => callback != c )
+  }
+
+  _onConsentChange(e){
+    this.onUpdate()
+    this.callbacks.forEach( cb => cb(this,e))
+  }
+
+  onUpdate(){
+    this.consentCategories    = this.getConsentCategories()
+    this.activeCategories     = this.getActiveCategories()
+    this.servicesList         = this.getServicesList()
+    this.availableServices    = this.getAvailableServices()
+    this.unavailableServices  = this.getUnavailableServices()
+    this._injectCode()
+  }
+
+  getActiveCategories(){
+    let categories = []
+    const { OnetrustActiveGroups } = window
+    if(OnetrustActiveGroups){
+      categories = OnetrustActiveGroups.split(',')
+                     .filter( id => id ) // REMOVE EMPTIES
+                     .map( id => CONSENT_CATEGORIES_DICTIONARY[id] || id )
+    }
+    return categories
+  }
+
+  getConsentCategories(){
+    let categories = CONSENT_CATEGORIES_DICTIONARY
+    return Object.keys(categories).map(key => categories[key])
+  }
+
+  isServiceAvailable(service){
+    let available = false
+    for(let category of SERVICES_CATEGORIES[service]){
+      available = this.activeCategories.includes(category)
+      if(!available) return
+    }
+    return available
+  }
+
+  getServicesList(){
+    return Object.keys(SERVICES_CATEGORIES)
+  }
+
+  getServiceCategoriesId(service){
+    const dictionary = CONSENT_CATEGORIES_DICTIONARY
+    const serviceCategories = SERVICES_CATEGORIES[service]
+    return serviceCategories.map(
+      categoryName => {
+        let categoryId
+        for(let id in dictionary){
+          if(dictionary[id] == categoryName){
+            return categoryId = id
+          }
+        }
+        return categoryId
+      }
+    )
+  }
+
+  getAvailableServices(){
+    return this.servicesList.filter(this.isServiceAvailable.bind(this))
+  }
+
+  getUnavailableServices(){
+    return this.servicesList.filter((service)=> !this.isServiceAvailable(service))
+  }
+
+  registerScript(service, code, parentNode){
+    this._registerScript({ service, code, parentNode })
+    /*
+      Right after the script is registered,
+      we'll try to inject it in case user already gave consent
+    */
+    this._injectCode()
+  }
+
+  _registerScript(service, code, parentNode = 'head'){
+    this.scripts.push({ service, code, parentNode })
+  }
+
+  insertScriptTag({ code , parentNode }){
+    const tag = document.createElement('script')
+    tag.type  = 'text/javascript'
+    document.querySelector(parentNode).appendChild(tag)
+    tag.src   = code
+  }
+
+  _injectCode(){
+    this.scripts.filter( script =>{
+      let keep = true
+      if(this.availableServices.includes(script.service)){
+        switch(typeof script.code){
+          case 'function':
+            script.code()
+            keep = false
+            break
+          case 'string':
+            this.insertScriptTag(script)
+            keep = false
+            break
+        }
+      }
+      return keep
+    })
+  }
+
+}
+
+const singleton = new UserConsent()
+
+export default singleton

--- a/src/services/UserConsent/index.test.js
+++ b/src/services/UserConsent/index.test.js
@@ -1,0 +1,78 @@
+import UserConsent from './index'
+
+describe('UserConsent', () => {
+
+  //-------------------------------------------------------------------------------
+
+  it(`Available services match user preferences (Strictly necessary)`, async () => {
+    window.OnetrustActiveGroups = ',C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getAvailableServices()).toMatchSnapshot()
+  })
+
+  it(`Active categories match user preferences (Strictly necessary)`, async () => {
+    window.OnetrustActiveGroups = ',C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getActiveCategories()).toMatchSnapshot()
+  })
+
+  //-------------------------------------------------------------------------------
+
+  it(`Available services match user preferences (Performance)`, async () => {
+    window.OnetrustActiveGroups = ',C0002,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getAvailableServices()).toMatchSnapshot()
+  })
+
+  it(`Active categories match user preferences (Performance)`, async () => {
+    window.OnetrustActiveGroups = ',C0002,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getActiveCategories()).toMatchSnapshot()
+  })
+
+  //-------------------------------------------------------------------------------
+
+  it(`Available services match user preferences (Functional)`, async () => {
+    window.OnetrustActiveGroups = ',C0003,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getAvailableServices()).toMatchSnapshot()
+  })
+
+  it(`Active categories match user preferences (Functional)`, async () => {
+    window.OnetrustActiveGroups = ',C0003,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getActiveCategories()).toMatchSnapshot()
+  })
+
+  //-------------------------------------------------------------------------------
+
+  it(`Available services match user preferences (Targeting)`, async () => {
+    window.OnetrustActiveGroups = ',C0004,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getAvailableServices()).toMatchSnapshot()
+  })
+
+  it(`Active categories match user preferences (Targeting)`, async () => {
+    window.OnetrustActiveGroups = ',C0004,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getActiveCategories()).toMatchSnapshot()
+  })
+
+  //-------------------------------------------------------------------------------
+
+  it(`Available services match user preferences (Social Media)`, async () => {
+    window.OnetrustActiveGroups = ',C0005,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getAvailableServices()).toMatchSnapshot()
+  })
+
+  it(`Active categories match user preferences (Social Media)`, async () => {
+    window.OnetrustActiveGroups = ',C0005,C0001,'
+    UserConsent.onUpdate()
+    expect(UserConsent.getActiveCategories()).toMatchSnapshot()
+  })
+
+
+
+
+})


### PR DESCRIPTION
### What problem is the code solving?
We need a consistent way of blocking integrations and code that relates to user privacy.  We gather users privacy consent through One Trust so the solution needs to be connected to it.

### How does this change address the problem?
A small service that translates One Trust's privacy categories into available categories and services. Also provides some methods to include scripts when user preferences change.

### Why is this the best solution?
It's centralized and we can maintain it from this repository, implementing it on all the stacks necessary.

### Does this PR include proper unit testing?
Yes

### Share the knowledge
Not much to share, plain javascript