### PR TITLE
[TEC-3493] Fix mobile menu height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",
@@ -39,7 +39,6 @@
     "lodash.get": "^4.4.2",
     "lodash.map": "^4.6.0",
     "lodash.throttle": "^4.1.1",
-    "nookies": "^2.3.0",
     "yup": "^0.29.1"
   },
   "devDependencies": {

--- a/src/components/MobileMenu/components/FooterSection/styled.js
+++ b/src/components/MobileMenu/components/FooterSection/styled.js
@@ -4,7 +4,7 @@ export const Footer = styled.ul`
   background: ${(p) => p.theme.colors.lightGray3};
   list-style: none;
   margin: auto 0 0 0;
-  padding: 0 25px 50px 25px;
+  padding: 0 25px;
   width: 100%;
 `
 

--- a/src/components/MobileMenu/styled.js
+++ b/src/components/MobileMenu/styled.js
@@ -23,6 +23,7 @@ export const NavigationPanel = styled.div`
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: -webkit-fill-available;
   left: 0;
   max-width: 400px;
   position: fixed;


### PR DESCRIPTION
### What problem is the code solving?
During QA round we found iPhone X browser bottom bar overrides part of the mobile menu

### How does this change address the problem?
we use a new height css property which takes just the visible screen without mobile bars

