### PR TITLE
[TEC-3528] Add Spree Admin menu option in Desktop Nav

### DIFF
--- a/src/components/Header/components/UserMenu/index.js
+++ b/src/components/Header/components/UserMenu/index.js
@@ -44,6 +44,7 @@ UserMenu.defaultProps = {
     { url: '/profile/history', title: 'header.userMenu.myOrders' },
     { url: '/profile/wish-list', title: 'header.userMenu.myWishList' },
     { url: '/profile/return', title: 'header.userMenu.returns' },
+    { url: '/shop/admin', title: 'header.userMenu.spreeAdmin' },
     { url: '/signout', title: 'header.userMenu.signOut' }
   ]
 }


### PR DESCRIPTION
## What problem is the code solving?
Desktop Nav / User Menu is missing Spree Admin option.
## How does this change address the problem?
By adding missing option link.
## Why is this the best solution?
As options its added to the same list of User Menu options.

### --> T O D O <--
### Verify if user has admin role.
(Please comment in solutions for this)