### PR TITLE
[TEC-3715] Don't prevent pointer events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.67",
+  "version": "1.3.68",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/MainSearch/index.js
+++ b/src/components/MainSearch/index.js
@@ -257,7 +257,7 @@ export class MainSearch extends PureComponent {
           </Content>
         </Wrapper>
         {isOpened && (
-          <Overlay onClickHandler={() => this.close()} show={false} />
+          <Overlay onClickHandler={() => this.close()} opacity={0} />
         )}
       </Position>
     )

--- a/src/components/common/Overlay/index.js
+++ b/src/components/common/Overlay/index.js
@@ -7,19 +7,18 @@ const Layer = styled.div`
   bottom: 0;
   height: 100%;
   left: 0;
-  opacity: ${(p) => (p.show ? 0 : 0.6)};
+  opacity: ${(p) => p.opacity};
   position: fixed;
   right: 0;
   top: 0;
   width: 100%;
   z-index: ${(p) => p.zIndex};
-  pointer-events: ${(p) => (p.show ? 'all' : 'none')};
 `
 
 export default function Overlay({
   innerRef,
   onClickHandler,
-  show = true,
+  opacity = 0.6,
   zIndex = 0
 }) {
   const ownRef = useRef(null)
@@ -32,6 +31,11 @@ export default function Overlay({
   })
 
   return (
-    <Layer ref={ownRef} onClick={onClickHandler} show={show} zIndex={zIndex} />
+    <Layer
+      ref={ownRef}
+      onClick={onClickHandler}
+      opacity={opacity}
+      zIndex={zIndex}
+    />
   )
 }


### PR DESCRIPTION
## What problem is the code solving?
![image](https://user-images.githubusercontent.com/2753482/93483569-53742880-f8d7-11ea-9daa-408a4d7a50cb.png)
In Prod, a user can interact with navigation while Search modal is open.
In our CMS and PDP, we render Search on top of entire screen with a semi transparent backdrop preventing background input.
## How does this change address the problem?
By rendering Search at same tree level as Header/nav component.
## Why is this the best solution?
So we don't have to struggle with `z-index` madness.
## Does this PR include proper unit testing?
No.
## Share the knowledge
🎁🧠