### PR TITLE
[TEC-3715] Scroll up when Search is open on mobile

### DIFF
--- a/src/components/common/Overlay/index.js
+++ b/src/components/common/Overlay/index.js
@@ -31,6 +31,11 @@ export default function Overlay({
   })
 
   return (
-    <Layer ref={ownRef} onClick={onClickHandler} show={show} zIndex={zIndex} />
+    <Layer
+      ref={ownRef}
+      onClick={onClickHandler}
+      opacity={opacity}
+      zIndex={zIndex}
+    />
   )
 }


### PR DESCRIPTION
## What problem is the code solving?
Continuing with #97 , when opening Search on mobile, page don't scroll up as on Desktop does.
## How does this change address the problem?
By making Search in mobile `position: absolute`, to `ref.focus()` can scroll up.
## Why is this the best solution?
So we have same behaviour as Desktop, and we don't have to hassle with `z-index` in order to have Header rendering on top of Search so users can interact with navigation while Search is open.
## Does this PR include proper unit testing?
No.
## Share the knowledge
🎁🧠