### PR TITLE
[TEC-3787] Don't render notification if there's no text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/NotificationsBar/NotificationBar/index.js
+++ b/src/components/NotificationsBar/NotificationBar/index.js
@@ -9,20 +9,24 @@ const NotificationBar = ({
   identifier,
   text,
   onDismiss
-}) => (
-  <Wrapper
-    backgroundColor={backgroundColor}
-    color={textColor}
-    hide={mustHideInMobile}
-  >
-    {text}
-    <Icon
-      onClick={() => onDismiss(identifier)}
+}) => {
+  if (!text) return null
+
+  return (
+    <Wrapper
+      backgroundColor={backgroundColor}
       color={textColor}
-      data-h='notification-close-btn'
-    />
-  </Wrapper>
-)
+      hide={mustHideInMobile}
+    >
+      {text}
+      <Icon
+        onClick={() => onDismiss(identifier)}
+        color={textColor}
+        data-h='notification-close-btn'
+      />
+    </Wrapper>
+  )
+}
 
 NotificationBar.propTypes = {
   backgroundColor: PropTypes.string,
@@ -37,7 +41,6 @@ NotificationBar.defaultProps = {
   backgroundColor: '#000',
   textColor: '#fff',
   mustHideInMobile: false,
-  text: [],
   onDismiss: () => {}
 }
 

--- a/src/components/NotificationsBar/index.js
+++ b/src/components/NotificationsBar/index.js
@@ -101,7 +101,7 @@ export class NotificationsBar extends React.Component {
 
   formatText(legend) {
     const formatLegend = documentToReactComponents(legend)
-    const text = get(formatLegend, '[0].props.children', [])
+    const text = get(formatLegend, '[0].props.children')
     return text
   }
 


### PR DESCRIPTION
## What problem is the code solving?
![image](https://user-images.githubusercontent.com/2753482/93779100-ff31b700-fbfc-11ea-9b63-3f60f08ad23b.png)
For some reason we lost ability to show notifications in other locales than `en-US`.
## How does this change address the problem?
By not relying in `exclusiveLocale` and just leave blank text of notification we don't want to get displayed.
## Why is this the best solution?
Is not but it's blocking the release of Header & Footer on CMS.

We can spike later why `exclusiveLocale` stoped working.
## Does this PR include proper unit testing?
No.
## Share the knowledge
🎁🧠