### PR TITLE
[TEC-3787] Remove usage of exclusiveLocales

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.72",
+  "version": "1.3.73",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/NotificationsBar/index.js
+++ b/src/components/NotificationsBar/index.js
@@ -101,7 +101,7 @@ export class NotificationsBar extends React.Component {
 
   formatText(legend) {
     const formatLegend = documentToReactComponents(legend)
-    const text = get(formatLegend, '[0].props.children')
+    const text = get(formatLegend, '[0].props.children', null)
     return text
   }
 

--- a/src/services/ContentfulApi.js
+++ b/src/services/ContentfulApi.js
@@ -383,14 +383,6 @@ export class ContentfulAPI {
     return formattedData
   }
 
-  filterNotificationsByLocale(bars, localeCode) {
-    return bars.filter(
-      (n) =>
-        !n.exclusiveLocales ||
-        (n.exclusiveLocales && n.exclusiveLocales.find((l) => l === localeCode))
-    )
-  }
-
   async getNotificationBars(localeCode) {
     try {
       const client = this.getClient()
@@ -398,12 +390,8 @@ export class ContentfulAPI {
         content_type: 'notificationBar',
         locale: localeCode || this.locale
       })
-      const formattedData = this.formatResponse(result)
-      const filtered = this.filterNotificationsByLocale(
-        formattedData,
-        localeCode
-      )
-      return filtered
+      const formatted = this.formatResponse(result)
+      return formatted && formatted.length && formatted[0]
     } catch (e) {
       console.log(e)
     }


### PR DESCRIPTION
## What problem is the code solving?
This is a continuation of #102 

We forgot to remove filtering logic by using `exclusiveLocales` from Contentful.
## How does this change address the problem?
By removing the filtering logic.
## Why is this the best solution?
So if `exclusiveLocales` gets used by human error, won't cause any confusion.

(we would still need to remove `exclusiveLocales` field from Contentful)