### PR TITLE
[TEC-3911] Add bar from ambassador & future

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.77",
+  "version": "1.3.78",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/DiscountNotificationBar/__snapshots__/test.js.snap
+++ b/src/components/DiscountNotificationBar/__snapshots__/test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DiscountNotificationBar Renders just fine if a name is provided 1`] = `
+<div>
+  <div
+    class="sc-AxjAm hVqvur"
+  >
+    <span>
+      This is a notification Roger Rabbit
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/DiscountNotificationBar/index.js
+++ b/src/components/DiscountNotificationBar/index.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormattedHTMLMessage } from 'react-intl'
+import RegularNotificationBar from 'components/RegularNotificationBar'
+
+const linkUrl = (host, url) => `${host}${url}`
+
+const DiscountNotificationBar = ({ apiHost, name, link }) => {
+  if (!name) return null
+  return (
+    <RegularNotificationBar>
+      <FormattedHTMLMessage
+        id='header.notifications.discount'
+        values={{
+          name,
+          link: linkUrl(apiHost, link)
+        }}
+      />
+    </RegularNotificationBar>
+  )
+}
+
+DiscountNotificationBar.defaultProps = {
+  apiHost: typeof window !== 'undefined' ? window.location.origin : '',
+  link: '/static/crewfineprint'
+}
+
+DiscountNotificationBar.propTypes = {
+  apiHost: PropTypes.string,
+  name: PropTypes.string,
+  link: PropTypes.string
+}
+
+export default DiscountNotificationBar

--- a/src/components/DiscountNotificationBar/test.js
+++ b/src/components/DiscountNotificationBar/test.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-unused-expressions */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import Theme from 'themes/styled'
+import { IntlProvider } from 'react-intl'
+
+import DiscountNotificationBar from './index'
+
+describe('DiscountNotificationBar', () => {
+  it('Renders nothing if no name', () => {
+    const { container } = render(<DiscountNotificationBar />)
+    expect(container).toBeNull
+  })
+
+  it('Renders just fine if a name is provided', () => {
+    const { container } = render(
+      <IntlProvider
+        locale='en'
+        messages={{
+          'header.notifications.discount': 'This is a notification {name}'
+        }}
+      >
+        <ThemeProvider theme={Theme}>
+          <DiscountNotificationBar name='Roger Rabbit' />
+        </ThemeProvider>
+      </IntlProvider>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/PosNotificationBar/styled.js
+++ b/src/components/PosNotificationBar/styled.js
@@ -1,16 +1,14 @@
 import styled from 'styled-components'
-import colors from 'styles/colors'
-import { fontWeight } from 'styles/settings'
 
 export const Wrapper = styled.div`
-  background-color: ${colors.black};
+  background-color: ${(p) => p.theme.colors.black};
   padding: 10px 20px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  color: ${colors.white};
-  font-weight: ${fontWeight.light};
+  color: ${(p) => p.theme.colors.white};
+  font-weight: ${(p) => p.theme.fontWeight.light};
   letter-spacing: 1px;
   line-height: 18px;
   font-size: 14px;
@@ -30,7 +28,7 @@ POSName.displayName = 'POSName'
 
 export const Buyer = styled.div`
   & > a {
-    color: ${colors.white};
+    color: ${(p) => p.theme.colors.white};
     white-space: nowrap;
 
     &:focus {

--- a/src/components/RegularNotificationBar/index.js
+++ b/src/components/RegularNotificationBar/index.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+
+const RegularNotificationBar = styled.div`
+  background-color: ${(p) => p.theme.colors.black};
+  padding: 10px 20px;
+  color: ${(p) => p.theme.colors.white};
+  font-size: 14px;
+  font-weight: ${(p) => p.theme.fontWeight.regular};
+  letter-spacing: 1px;
+  line-height: 18px;
+  text-align: center;
+  -webkit-text-stroke: initial;
+
+  @media (min-width: 768px) {
+    padding: 12px;
+    font-size: 15px;
+  }
+
+  a {
+    color: ${(p) => p.theme.colors.white};
+    transition: color 0.3s ease;
+    text-decoration: underline;
+
+    &:hover {
+      color: ${(p) => p.theme.colors.grey};
+    }
+  }
+`
+
+export default RegularNotificationBar

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import Footer from './components/Footer'
 import CurrencySelector from './components/CurrencySelector'
 import OnboardingModal from './components/OnboardingModal'
 import PosNotificationBar from './components/PosNotificationBar'
+import DiscountNotificationBar from './components/DiscountNotificationBar'
 import {
   ClientStateProvider,
   ClientStateContext
@@ -57,6 +58,7 @@ export {
   Spinner,
   ButtonLink,
   PosNotificationBar,
+  DiscountNotificationBar,
   ClientStateProvider,
   ClientStateContext
 }


### PR DESCRIPTION
## What problem is the code solving?
- Adds a generic new bar to be used with ambassador RN and reused in future to build the rest of the bars when they become a carousel

## How does this change address the problem?
- We have the bar to show now, and we reuse it in future to build all the bars

## Why is this the best solution?
- Reusable and cleaner than today

## Does this PR include proper unit testing?
- Yep, some

