### PR TITLE
[TEC-3975] Parse deep nested generic components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.86",
+  "version": "1.3.87",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/services/ContentfulApi.mock.js
+++ b/src/services/ContentfulApi.mock.js
@@ -1399,4 +1399,329 @@ const componentGeneric = {
 	}
 }
 
-export const mockData = { lookPage, componentGeneric, cloudinaryImageData }
+const pageGeneric = {
+  items : [
+    {
+    	"sys": {
+    		"space": {
+    			"sys": {
+    				"type": "Link",
+    				"linkType": "Space",
+    				"id": "e48r2iwyjczp"
+    			}
+    		},
+    		"id": "2rczcQGdjFigxvc0SAyMp2",
+    		"type": "Entry",
+    		"createdAt": "2020-09-28T16:44:41.685Z",
+    		"updatedAt": "2020-09-28T18:21:57.290Z",
+    		"environment": {
+    			"sys": {
+    				"id": "staging",
+    				"type": "Link",
+    				"linkType": "Environment"
+    			}
+    		},
+    		"revision": 4,
+    		"contentType": {
+    			"sys": {
+    				"type": "Link",
+    				"linkType": "ContentType",
+    				"id": "pageGeneric"
+    			}
+    		},
+    		"locale": "en-US"
+    	},
+    	"fields": {
+    		"title": "Home test",
+    		"slug": "homepage",
+    		"components": [
+    			{
+    				"sys": {
+    					"space": {
+    						"sys": {
+    							"type": "Link",
+    							"linkType": "Space",
+    							"id": "e48r2iwyjczp"
+    						}
+    					},
+    					"id": "2NVpKVenrJEZtw1ivfLyLF",
+    					"type": "Entry",
+    					"createdAt": "2020-09-28T16:54:52.867Z",
+    					"updatedAt": "2020-09-28T17:04:34.337Z",
+    					"environment": {
+    						"sys": {
+    							"id": "staging",
+    							"type": "Link",
+    							"linkType": "Environment"
+    						}
+    					},
+    					"revision": 2,
+    					"contentType": {
+    						"sys": {
+    							"type": "Link",
+    							"linkType": "ContentType",
+    							"id": "componentGeneric"
+    						}
+    					},
+    					"locale": "en-US"
+    				},
+    				"fields": {
+    					"name": "home test",
+    					"data": {
+    						"data": {
+    							"components": [
+    								{
+    									"data": {
+    										"content": "hello world"
+    									},
+    									"name": "",
+    									"type": "text",
+    									"behaviours": [],
+    									"referenceId": "1-1601312085538",
+    									"cssByBreakpoint": [
+    										{
+    											"css": [],
+    											"cssHover": [],
+    											"cssActive": [],
+    											"breakpoint": {
+    												"minWidth": 0,
+    												"orientation": "all"
+    											},
+    											"cssDisabled": []
+    										}
+    									]
+    								},
+    								{
+    									"data": {
+    										"entryId": "1h7nECti5sNzqLeQ3P45N5"
+    									},
+    									"name": "",
+    									"type": "richText",
+    									"behaviours": [],
+    									"referenceId": "2-1601312353594",
+    									"cssByBreakpoint": [
+    										{
+    											"css": [],
+    											"cssHover": [],
+    											"cssActive": [],
+    											"breakpoint": {
+    												"minWidth": 0,
+    												"orientation": "all"
+    											},
+    											"cssDisabled": []
+    										}
+    									]
+    								}
+    							]
+    						},
+    						"name": "",
+    						"type": "container",
+    						"behaviours": [],
+    						"referenceId": "0-1601312079429",
+    						"cssByBreakpoint": [
+    							{
+    								"css": [],
+    								"cssHover": [],
+    								"cssActive": [],
+    								"breakpoint": {
+    									"minWidth": 0,
+    									"orientation": "all"
+    								},
+    								"cssDisabled": []
+    							}
+    						]
+    					},
+    					"linkedEntries": [
+    						{
+    							"sys": {
+    								"space": {
+    									"sys": {
+    										"type": "Link",
+    										"linkType": "Space",
+    										"id": "e48r2iwyjczp"
+    									}
+    								},
+    								"id": "1h7nECti5sNzqLeQ3P45N5",
+    								"type": "Entry",
+    								"createdAt": "2020-09-28T16:59:31.734Z",
+    								"updatedAt": "2020-09-28T16:59:31.734Z",
+    								"environment": {
+    									"sys": {
+    										"id": "staging",
+    										"type": "Link",
+    										"linkType": "Environment"
+    									}
+    								},
+    								"revision": 1,
+    								"contentType": {
+    									"sys": {
+    										"type": "Link",
+    										"linkType": "ContentType",
+    										"id": "richTextGeneric"
+    									}
+    								},
+    								"locale": "en-US"
+    							},
+    							"fields": {
+    								"name": "rich test",
+    								"content": {
+    									"nodeType": "document",
+    									"data": {},
+    									"content": [
+    										{
+    											"nodeType": "paragraph",
+    											"content": [
+    												{
+    													"nodeType": "text",
+    													"value": "HOla desde rich",
+    													"marks": [],
+    													"data": {}
+    												}
+    											],
+    											"data": {}
+    										}
+    									]
+    								}
+    							}
+    						}
+    					]
+    				}
+    			},
+    			{
+    				"sys": {
+    					"space": {
+    						"sys": {
+    							"type": "Link",
+    							"linkType": "Space",
+    							"id": "e48r2iwyjczp"
+    						}
+    					},
+    					"id": "DporMEWCVGQIU9mFEr76N",
+    					"type": "Entry",
+    					"createdAt": "2020-09-28T17:07:59.664Z",
+    					"updatedAt": "2020-09-28T17:07:59.664Z",
+    					"environment": {
+    						"sys": {
+    							"id": "staging",
+    							"type": "Link",
+    							"linkType": "Environment"
+    						}
+    					},
+    					"revision": 1,
+    					"contentType": {
+    						"sys": {
+    							"type": "Link",
+    							"linkType": "ContentType",
+    							"id": "componentGeneric"
+    						}
+    					},
+    					"locale": "en-US"
+    				},
+    				"fields": {
+    					"name": "home test 2",
+    					"data": {
+    						"name": "",
+    						"cssByBreakpoint": [
+    							{
+    								"breakpoint": {
+    									"orientation": "all",
+    									"minWidth": 0
+    								},
+    								"css": [],
+    								"cssHover": [],
+    								"cssActive": [],
+    								"cssDisabled": []
+    							}
+    						],
+    						"behaviours": [],
+    						"type": "container",
+    						"data": {
+    							"components": [
+    								{
+    									"name": "",
+    									"cssByBreakpoint": [
+    										{
+    											"breakpoint": {
+    												"orientation": "all",
+    												"minWidth": 0
+    											},
+    											"css": [],
+    											"cssHover": [],
+    											"cssActive": [],
+    											"cssDisabled": []
+    										}
+    									],
+    									"behaviours": [],
+    									"type": "richText",
+    									"data": {
+    										"entryId": "Fsd4JmUc6TfXwX59ptn8M"
+    									},
+    									"referenceId": "1-1601312866804"
+    								}
+    							]
+    						},
+    						"referenceId": "0-1601312858380"
+    					},
+    					"linkedEntries": [
+    						{
+    							"sys": {
+    								"space": {
+    									"sys": {
+    										"type": "Link",
+    										"linkType": "Space",
+    										"id": "e48r2iwyjczp"
+    									}
+    								},
+    								"id": "Fsd4JmUc6TfXwX59ptn8M",
+    								"type": "Entry",
+    								"createdAt": "2020-09-28T17:07:56.311Z",
+    								"updatedAt": "2020-09-28T17:07:56.311Z",
+    								"environment": {
+    									"sys": {
+    										"id": "staging",
+    										"type": "Link",
+    										"linkType": "Environment"
+    									}
+    								},
+    								"revision": 1,
+    								"contentType": {
+    									"sys": {
+    										"type": "Link",
+    										"linkType": "ContentType",
+    										"id": "richTextGeneric"
+    									}
+    								},
+    								"locale": "en-US"
+    							},
+    							"fields": {
+    								"name": "New rich text another",
+    								"content": {
+    									"nodeType": "document",
+    									"data": {},
+    									"content": [
+    										{
+    											"nodeType": "paragraph",
+    											"content": [
+    												{
+    													"nodeType": "text",
+    													"value": "Another test",
+    													"marks": [],
+    													"data": {}
+    												}
+    											],
+    											"data": {}
+    										}
+    									]
+    								}
+    							}
+    						}
+    					]
+    				}
+    			}
+    		]
+    	}
+    }
+  ]
+}
+
+export const mockData = { pageGeneric, lookPage, componentGeneric, cloudinaryImageData }

--- a/src/services/ContentfulApi.test.js
+++ b/src/services/ContentfulApi.test.js
@@ -37,13 +37,20 @@ describe('ContentfulAPI', () => {
     expect(response).toMatchSnapshot()
   })
 
+  it('It formats generic components deep nested in a response', async () => {
+    const instance = new ContentfulAPI(credentials)
+    const response = await instance.getContentType('pageGeneric', {
+      id: '1egd1bENEWRUWOXBRVZEUq',
+      client: mockedContentfulClient
+    })
+    expect(response).toMatchSnapshot()
+  })
+
   it('It formats cloudinary images data', async () => {
     const instance = new ContentfulAPI(credentials)
     const formatted = instance.formatCloudinaryData(mockData.cloudinaryImageData)
     expect(formatted).toMatchSnapshot()
   })
-
-
 
   it('It fetches lookbook pages', async () => {
     const instance = new ContentfulAPI(credentials)

--- a/src/services/__snapshots__/ContentfulApi.test.js.snap
+++ b/src/services/__snapshots__/ContentfulApi.test.js.snap
@@ -939,6 +939,175 @@ Object {
 }
 `;
 
+exports[`ContentfulAPI It formats generic components deep nested in a response 1`] = `
+Array [
+  Object {
+    "_contentType": Object {
+      "_id": "pageGeneric",
+    },
+    "_id": "2rczcQGdjFigxvc0SAyMp2",
+    "_locale": "en-US",
+    "components": Array [
+      Object {
+        "behaviours": Array [],
+        "cssByBreakpoint": Array [
+          Object {
+            "breakpoint": Object {
+              "minWidth": 0,
+              "orientation": "all",
+            },
+            "css": Array [],
+            "cssActive": Array [],
+            "cssDisabled": Array [],
+            "cssHover": Array [],
+          },
+        ],
+        "data": Object {
+          "components": Array [
+            Object {
+              "behaviours": Array [],
+              "cssByBreakpoint": Array [
+                Object {
+                  "breakpoint": Object {
+                    "minWidth": 0,
+                    "orientation": "all",
+                  },
+                  "css": Array [],
+                  "cssActive": Array [],
+                  "cssDisabled": Array [],
+                  "cssHover": Array [],
+                },
+              ],
+              "data": Object {
+                "content": "hello world",
+              },
+              "name": "",
+              "referenceId": "1-1601312085538",
+              "type": "text",
+            },
+            Object {
+              "behaviours": Array [],
+              "cssByBreakpoint": Array [
+                Object {
+                  "breakpoint": Object {
+                    "minWidth": 0,
+                    "orientation": "all",
+                  },
+                  "css": Array [],
+                  "cssActive": Array [],
+                  "cssDisabled": Array [],
+                  "cssHover": Array [],
+                },
+              ],
+              "data": Object {
+                "_contentType": Object {
+                  "_id": "richTextGeneric",
+                },
+                "_id": "1h7nECti5sNzqLeQ3P45N5",
+                "_locale": "en-US",
+                "content": Object {
+                  "content": Array [
+                    Object {
+                      "content": Array [
+                        Object {
+                          "data": Object {},
+                          "marks": Array [],
+                          "nodeType": "text",
+                          "value": "HOla desde rich",
+                        },
+                      ],
+                      "data": Object {},
+                      "nodeType": "paragraph",
+                    },
+                  ],
+                  "data": Object {},
+                  "nodeType": "document",
+                },
+                "name": "rich test",
+              },
+              "name": "",
+              "referenceId": "2-1601312353594",
+              "type": "richText",
+            },
+          ],
+        },
+        "name": "",
+        "referenceId": "0-1601312079429",
+        "type": "container",
+      },
+      Object {
+        "behaviours": Array [],
+        "cssByBreakpoint": Array [
+          Object {
+            "breakpoint": Object {
+              "minWidth": 0,
+              "orientation": "all",
+            },
+            "css": Array [],
+            "cssActive": Array [],
+            "cssDisabled": Array [],
+            "cssHover": Array [],
+          },
+        ],
+        "data": Object {
+          "components": Array [
+            Object {
+              "behaviours": Array [],
+              "cssByBreakpoint": Array [
+                Object {
+                  "breakpoint": Object {
+                    "minWidth": 0,
+                    "orientation": "all",
+                  },
+                  "css": Array [],
+                  "cssActive": Array [],
+                  "cssDisabled": Array [],
+                  "cssHover": Array [],
+                },
+              ],
+              "data": Object {
+                "_contentType": Object {
+                  "_id": "richTextGeneric",
+                },
+                "_id": "Fsd4JmUc6TfXwX59ptn8M",
+                "_locale": "en-US",
+                "content": Object {
+                  "content": Array [
+                    Object {
+                      "content": Array [
+                        Object {
+                          "data": Object {},
+                          "marks": Array [],
+                          "nodeType": "text",
+                          "value": "Another test",
+                        },
+                      ],
+                      "data": Object {},
+                      "nodeType": "paragraph",
+                    },
+                  ],
+                  "data": Object {},
+                  "nodeType": "document",
+                },
+                "name": "New rich text another",
+              },
+              "name": "",
+              "referenceId": "1-1601312866804",
+              "type": "richText",
+            },
+          ],
+        },
+        "name": "",
+        "referenceId": "0-1601312858380",
+        "type": "container",
+      },
+    ],
+    "slug": "homepage",
+    "title": "Home test",
+  },
+]
+`;
+
 exports[`ContentfulAPI Query Options are formatted properly 1`] = `
 Object {
   "fields.slug": "chain-reaction",


### PR DESCRIPTION
## What problem is the code solving?
If we link a `componentGeneric` from a `pageGeneric` or any other contentType it will not get parsed properly, since the method doing that only checks for the root level of the data.

## How does this change address the problem?
A little update on the flow of the parsing methods, that searches for `componentGenerics` on every level of an object.
Also added a default `include` property of `10` which is the maximum. This is because linked data wasn't fetched properly from the API. (More info about this below)

## Why is this the best solution?
Well it's great, this makes the new componentGeneric types "compatible" with the existing content types from editorial, at least from this API/formatting standpoint.

## Does this PR include proper unit testing?
Yes

## Share the knowledge
About the `include` argument for contentful:
https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links