### PR TITLE
[NO-TICKET] Fix Desktop menu hovering issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.3.94",
+  "version": "1.3.95",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/Header/components/Navigation/index.js
+++ b/src/components/Header/components/Navigation/index.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Wrapper, Item, ItemLink, Layer, Layers } from './styled'
+import {
+  Wrapper,
+  Item,
+  ItemLink,
+  LayerBackground,
+  LayerContainer
+} from './styled'
 import get from 'lodash.get'
 import LayerContent from './components/LayerContent'
 
@@ -30,8 +36,8 @@ export const Navigation = ({
           >
             {i.text}
           </ItemLink>
-          <Layer active={i._id === activeSection} shrinked={shrinked}>
-            <Layers active={i._id === activeSection} />
+          <LayerContainer active={i._id === activeSection} shrinked={shrinked}>
+            <LayerBackground active={i._id === activeSection} />
             {i.children && (
               <LayerContent
                 config={i.children}
@@ -39,7 +45,7 @@ export const Navigation = ({
                 pos={pos}
               />
             )}
-          </Layer>
+          </LayerContainer>
         </Item>
       ))}
     </Wrapper>

--- a/src/components/Header/components/Navigation/styled.js
+++ b/src/components/Header/components/Navigation/styled.js
@@ -38,16 +38,17 @@ export const ItemLink = styled.a`
   }
 `
 
-export const Layer = styled.div`
+export const LayerContainer = styled.div`
   display: flex;
   opacity: ${(p) => (p.active ? '1' : '0')};
+  pointer-events: ${(p) => (p.active ? 'auto' : 'none')};
   transition: 0.5s opacity;
   position: absolute;
   top: ${(p) => (p.shrinked ? '36px' : '51px')};
   width: 100vw;
 `
 
-export const Layers = styled.div`
+export const LayerBackground = styled.div`
   background: white;
   border-bottom: 1px solid ${colors.whiteSmoke};
   display: flex;


### PR DESCRIPTION
## What problem is the code solving?
When hovering over Desktop nav links, overlays will ignore cursor hovering.
## How does this change address the problem?
Because all overlays are been render in DOM but with opacity 0, the last (on-top) one will receive the hovering.
So, if an overlay is not currently active, then make it ignore pointer events.
## Why is this the best solution?
So we can have proper transition animations when showing/hiding overlays.
