### PR TITLE
[TEC-4152] Desktop Header User name too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mejuri-inc/mejuri-components",
-  "version": "1.11.0",
+  "version": "1.13.0",
   "description": "Mejuri components library",
   "license": "ISC",
   "author": "joaenriquez@gmail.com",

--- a/src/components/Header/components/HeaderDesktop/styled.js
+++ b/src/components/Header/components/HeaderDesktop/styled.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import LogoSvg from 'resources/icons/Logo'
 
 export const MejuriLogo = styled(LogoSvg)`
+  width: auto;
   height: 100%;
   &:hover {
     fill: inherit;
@@ -12,11 +13,6 @@ export const Logo = styled.a`
   height: ${({ shrinked }) => (shrinked ? '45px' : '58px')};
   text-transform: uppercase;
   text-align: center;
-  flex-basis: 56%;
-
-  @media (max-width: 1200px) {
-    flex-basis: 33.3%;
-  }
 `
 
 export const Wrapper = styled.section`
@@ -60,7 +56,7 @@ export const Menu = styled.nav`
   flex-basis: 33.3%;
 
   @media (min-width: 1200px) {
-    flex-basis: 22%;
+    flex-basis: 30%;
   }
 
   svg {

--- a/src/components/Header/components/Navigation/styled.js
+++ b/src/components/Header/components/Navigation/styled.js
@@ -9,7 +9,7 @@ export const Wrapper = styled.div`
   flex-basis: 33.3%;
 
   @media (min-width: 1200px) {
-    flex-basis: 22%;
+    flex-basis: 30%;
   }
 `
 Wrapper.displayName = 'WrapperNavigation'

--- a/src/components/Header/components/UserMenu/styled.js
+++ b/src/components/Header/components/UserMenu/styled.js
@@ -43,7 +43,7 @@ Wrapper.displayName = 'WrapperUserMenu'
 
 export const LabelChevron = styled.span`
   letter-spacing: 1px;
-  max-width: 80px;
+  max-width: 57px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
## What problem is the code solving?
User name is 9 characters long
![image](https://user-images.githubusercontent.com/2753482/97023913-88097e80-152c-11eb-9983-f42539285f55.png)
Should be 7 like old stacker header
![image](https://user-images.githubusercontent.com/2753482/97023972-9ce61200-152c-11eb-8d7d-696da470d727.png)
## How does this change address the problem?
Reduce width of username to fit only 7 characters.
## Why is this the best solution?
So the right content won't push mejuri logo to the left.
## Does this PR include proper unit testing?
No need. It's only style change.