### PR TITLE
[TEC-4577] Legal link on footer mobile not showing

### DIFF
--- a/src/components/Footer/Components/MobileSubFooter/index.js
+++ b/src/components/Footer/Components/MobileSubFooter/index.js
@@ -7,7 +7,7 @@ import get from 'lodash.get'
 
 function MobileSubFooter({ socialLinks, currencySelector, config }) {
   const legalLinks = config.children.find(function (x) {
-    const isLegal = get(x, 'fields.extraFields.legal', false)
+    const isLegal = get(x, 'extraFields.legal', false)
     return isLegal
   })
   return (


### PR DESCRIPTION
## What problem is the code solving?
Legal link on footer mobile not rendering

## How does this change address the problem?
The code was looking for an old key _fields.extrafields_......
Fields is no longer in use.
Desktop link are showing and now they code is the same.

## Share the knowledge
